### PR TITLE
Make it build on GHC 7.10.

### DIFF
--- a/src/Data/Union/ST.hs
+++ b/src/Data/Union/ST.hs
@@ -3,7 +3,7 @@
 --
 -- Authors: Bertram Felgenhauer
 
-{-# LANGUAGE RankNTypes, CPP #-}
+{-# LANGUAGE RankNTypes, CPP, FlexibleContexts #-}
 -- |
 -- Low-level interface for managing a disjoint set data structure, based on
 -- 'Control.Monad.ST'. For a higher level convenience interface, look at


### PR DESCRIPTION
Hi,

The `union-find-array` package no longer compiles on GHC 7.10, as the compiler now checks when it infers a type that the type declaration would be accepted if you wrote it by hand. The type of the local function `cont` under `Data.Union.ST.merge` requires `FlexibleContexts`, so GHC complains. This patch just adds a `FlexibleContexts` pragma to the file to make GHC happy.
