### PR TITLE
Export orphan ST Applicative instance from base-orphans

### DIFF
--- a/src/Data/Union/ST.hs
+++ b/src/Data/Union/ST.hs
@@ -3,7 +3,7 @@
 --
 -- Authors: Bertram Felgenhauer
 
-{-# LANGUAGE RankNTypes, FlexibleContexts, CPP #-}
+{-# LANGUAGE RankNTypes, FlexibleContexts #-}
 -- |
 -- Low-level interface for managing a disjoint set data structure, based on
 -- 'Control.Monad.ST'. For a higher level convenience interface, look at
@@ -31,6 +31,7 @@ import Control.Applicative
 import Data.Array.Base hiding (unsafeFreeze)
 import Data.Array.ST hiding (unsafeFreeze)
 import qualified Data.Array.Base as A (unsafeFreeze)
+import Data.Orphans ()
 
 -- | A disjoint set forest, with nodes numbered from 0, which can carry labels.
 data UnionST s l = UnionST {
@@ -40,12 +41,6 @@ data UnionST s l = UnionST {
     size :: !Int,
     def :: l
 }
-
-#if __GLASGOW_HASKELL__ < 702
-instance Applicative (ST s) where
-    (<*>) = ap
-    pure = return
-#endif
 
 -- Use http://www.haskell.org/pipermail/libraries/2008-March/009465.html ?
 

--- a/union-find-array.cabal
+++ b/union-find-array.cabal
@@ -34,7 +34,8 @@ library
     build-depends:
         array >= 0.3 && < 0.6,
         mtl >= 1.1 && < 2.3,
-        base >= 4 && < 5
+        base >= 4 && < 5,
+        base-orphans >= 0.1 && < 0.4
     extensions:
         GeneralizedNewtypeDeriving
         RankNTypes


### PR DESCRIPTION
This pull request replaces `union-find-array`'s orphan `Applicative ST` instance with one exported from the `base-orphans` library. This helps mitigate the possibility of other libraries defining an `Applicative ST` instance and failing to compile if used together with `union-find-array` on early versions of GHC.
