### PR TITLE
Remove noncanonical definitions.

### DIFF
--- a/src/Control/Monad/Union.hs
+++ b/src/Control/Monad/Union.hs
@@ -40,14 +40,13 @@ newtype UnionM l a = U {
 }
 
 instance Monad (UnionM l) where
-    return x =  U (return x)
     f >>= b = U (runU f >>= \v -> runU (b v))
 
 instance Functor (UnionM l) where
     fmap = liftM
 
 instance Applicative (UnionM l) where
-    pure = return
+    pure x =  U (return x)
     (<*>) = ap
 
 instance MonadFix (UnionM l) where


### PR DESCRIPTION
This appeases the `-Wnoncanonical-monad-instances` warning. A future GHC release will treat noncanonical definitions as errors. See https://github.com/haskell/core-libraries-committee/issues/328.